### PR TITLE
Remove Meta Keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
 <meta name="description" content="Description">
-<meta name="keywords" content="Keywords">
 <title>Page Title</title>
 
 <!-- Android  -->


### PR DESCRIPTION
The meta keywords tag is no longer used by browsers and can be safely removed from the list of "must use tags".

Refer: https://www.semrush.com/blog/meta-keywords/